### PR TITLE
Make full article body available through API

### DIFF
--- a/src/zeit/api/queries.py
+++ b/src/zeit/api/queries.py
@@ -430,7 +430,7 @@ class ContentIdQuery(Query):
 		categories = [('department', 'department'), ('product', 'product'),
 			('sub_department', 'department'), ('series', 'series')]
 		whitelist = ['categories', 'creators', 'keywords', 'relations']
-		blacklist = ['body']
+		blacklist = []
 
 		for key in whitelist:
 			doc[key] = []


### PR DESCRIPTION
Please make the article body available through the API. A tiny commit for me, a huge opportunity for Zeit.de and German journalism. :wink:

What kind of bad could realistically happen with the body available through the API that couldn't happen right now as well?

Of course this is rather a political problem than a technical one. But I love starting conversations through pull requests, so here we go.
