### PR TITLE
Generate key helper

### DIFF
--- a/generate-key.py
+++ b/generate-key.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+import os
+import sqlite3
+import sys
+import time
+
+if len(sys.argv) < 3:
+    raise ValueError('Usage: %s "Firstnam Lastname" email@example.com' % sys.argv[0])
+
+db = sqlite3.connect('/var/lib/zon-api/data.db')
+api_key = str(os.urandom(26).encode('hex'))
+tier = 'free'
+name = sys.argv[1]
+email = sys.argv[2]
+requests = 0
+reset = int(time.time())
+query = 'INSERT INTO client VALUES (?, ?, ?, ?, ?, ?)'
+db.execute(query, (api_key, tier, name, email, requests, reset))
+db.commit()
+db.close()
+print api_key

--- a/generate-key.py
+++ b/generate-key.py
@@ -5,10 +5,16 @@ import sqlite3
 import sys
 import time
 
-if len(sys.argv) < 3:
-    raise ValueError('Usage: %s "Firstnam Lastname" email@example.com' % sys.argv[0])
-
 db = sqlite3.connect('/var/lib/zon-api/data.db')
+
+if len(sys.argv) < 3:
+    print('Usage: %s "Firstname Lastname" email@example.com' % sys.argv[0])
+    print('\nLast keys:')
+    query = 'SELECT * FROM client ORDER by reset DESC limit 10'
+    for client in db.execute(query):
+        print('{0}: "{2}" {3}'.format(*client))
+    sys.exit(1)
+
 api_key = str(os.urandom(26).encode('hex'))
 tier = 'free'
 name = sys.argv[1]


### PR DESCRIPTION
Für 1e01e66f23f7a2ca541a29d29658749f95352c41 wollte ich zuerst mal das Skript ins Repo "retten", hab' dann aber gemerkt, daß auf developer.zeit.de (in `/usr/local/content-api`) lediglich 7c2a2e86f2a84c73e839ae809375ea205a2c4e43 deployed ist (und https://github.com/ZeitOnline/content-api/compare/7c2a2e86f2a84c73e839ae809375ea205a2c4e43...master also fehlt).

Das sollten wir wahrscheinlich (im Rahmen von [ZON-4721](https://zeit-online.atlassian.net/browse/ZON-4721)) mal aufräumen, aber bis dahin gibt's erstmal diesen Branch... 😛