### PR TITLE
"Searchable" keys.

### DIFF
--- a/generate-key.py
+++ b/generate-key.py
@@ -12,7 +12,7 @@ if len(sys.argv) < 3:
     print('\nLast keys:')
     query = 'SELECT * FROM client ORDER by reset DESC limit 10'
     for client in db.execute(query):
-        print('{0}: "{2}" {3}'.format(*client))
+        print(u'{0}: "{2}" {3}'.format(*client).encode('utf8'))
     sys.exit(1)
 
 api_key = str(os.urandom(26).encode('hex'))

--- a/generate-key.py
+++ b/generate-key.py
@@ -10,7 +10,7 @@ db = sqlite3.connect('/var/lib/zon-api/data.db')
 if len(sys.argv) < 3:
     print('Usage: %s "Firstname Lastname" email@example.com' % sys.argv[0])
     print('\nLast keys:')
-    query = 'SELECT * FROM client ORDER by reset DESC limit 10'
+    query = 'SELECT * FROM client ORDER by reset DESC'
     for client in db.execute(query):
         print(u'{0}: "{2}" {3}'.format(*client).encode('utf8'))
     sys.exit(1)


### PR DESCRIPTION
This is a follow-up for #30, which enables us to `grep` for existing names:
```bash
$ ssh developer.zeit.de /usr/local/content-api/generate-key.py | grep Mustermann
```